### PR TITLE
Start work on version 2.0 aimed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A [SwiftLog](https://github.com/apple/swift-log)  `LogHandler` that logs GCP Sta
 For more information on Stackdriver structured logging, see: https://cloud.google.com/logging/docs/structured-logging and [LogEntry](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry)
 
 ## Dependencies 
-This Stackdriver `LogHandler` has a dependency on [SwiftNIO](https://github.com/apple/swift-nio) which is used to create and save your new log entries in a non-blocking fashion. 
+This Stackdriver `LogHandler` depends on [SwiftNIO](https://github.com/apple/swift-nio) which is used to create and save your new log entries in a non-blocking fashion. 
 
 ## How to install
 
@@ -19,29 +19,45 @@ In your target's dependencies add `"StackdriverLogging"` e.g. like this:
 ```
 
 ## Bootstrapping 
-**Check out [bootstrapping Stackdriver logging for a Vapor 4 application](https://gist.github.com/jordanebelanger/4307bf34b4ff256c9c8ec52d94db905b) for a practical example using Vapor 4.**
-
-A factory is used to instantiate `StackdriverLogHandler` instances. Before bootstrapping your `LoggingSystem`, you must first call the  `StackdriverLogHandlerFactory.prepare(:)` function with a `StackdriverLoggingConfiguration`, an NIO `NonBlockingFileIO` to write the logs asynchronously and an `EventLoopGroup` used to process new log entries in the background.
-
-You are responsible for gracefully shutting down the NIO dependencies used to prepare the `StackdriverLogHandlerFactory`.
-
-Here's an example of how this works:
-```Swift
-let config = StackdriverLoggingConfiguration(logFilePath: "var/log/myapp.log", defaultLogLevel: "debug")
-
-let threadPool = NIOThreadPool(numberOfThreads: NonBlockingFileIO.defaultThreadPoolSize)
-threadPool.start()
-let fileIO = NonBlockingFileIO(threadPool: threadPool)
-let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: NonBlockingFileIO.defaultThreadPoolSize)
-
-StackdriverLogHandlerFactory.prepare(with: configuration,
-                                     fileIO: fileIO,
-                                     eventLoopGroup: eventLoopGroup)
-
+A factory is used to instantiate `StackdriverLogHandler` instances. Before bootstrapping your swift-log `LoggingSystem`, you must first call the  `StackdriverLogHandler.Factory.prepare(_:_:)` with your logging destination.
+The Logging destination can be either the standard output which would be whats expected under a gcp Cloud Run environment or a file of your choice. 
+You are also responsible for gracefully shutting down the NIO dependencies used internally by the `StackdriverLogHandler.Factory` by calling its shutdown function, preferably in a defer statement right after preparing the factory.
+```swift
+try StackdriverLogHandler.Factory.prepare(for: .stdout)
+defer {
+    try! StackdriverLogHandler.Factory.syncShutdownGracefully()
+}
+let logLevel = Logger.Level.info
 LoggingSystem.bootstrap { label -> LogHandler in
-    return StackdriverLogHandlerFactory.make()
+    var logger = StackdriverLogHandler.Factory.make()
+    logger.logLevel = logLevel
+    return logger
 }
 ```
+### Vapor 4
+Here's a bootstrapping example for a standard Vapor 4 application.
+```swift
+import App
+import Vapor
+
+var env = try Environment.detect()
+try StackdriverLogHandler.Factory.prepare(for: .stdout)
+defer {
+    try! StackdriverLogHandler.Factory.syncShutdownGracefully()
+}
+try LoggingSystem.bootstrap(from: &env) { (logLevel) -> (String) -> LogHandler in
+    return { label -> LogHandler in
+        var logger = StackdriverLogHandler.Factory.make()
+        logger.logLevel = logLevel
+        return logger
+    }
+}
+let app = Application(env)
+defer { app.shutdown() }
+try configure(app)
+try app.run()
+```
+
 ## Logging JSON values using `Logger.MetadataValue`
 To log metadata values as JSON, simply log all JSON values other than `String` as a `Logger.MetadataValue.stringConvertible` and, instead of the usual conversion of your value to a `String` in the log entry, it will keep the original JSON type of your values whenever possible.
 
@@ -91,8 +107,10 @@ Will log the non pretty-printed representation of:
 ```
 
 ## Stackdriver logging agent + fluentd config 
-You must use this LogHandler in combination with the Stackdriver logging agent https://cloud.google.com/logging/docs/agent/installation and a matching json format
-google-fluentd config (/etc/google-fluentd/config.d/example.conf) to automatically send your JSON logs to Stackdriver. 
+You should preferably run the agent using the standard output destination `StackdriverLogHandler.Destination.stdout` which will get you up and running automatically under certain gcp environments such as Cloud Run.
+
+If you prefer logging to a file, you can use a file destination `StackdriverLogHandler.Destination.stdout` in combination with the Stackdriver logging agent https://cloud.google.com/logging/docs/agent/installation and a matching json format
+google-fluentd config (/etc/google-fluentd/config.d/example.conf) to automatically send your JSON logs to Stackdriver for you. 
 
 Here's an example google-fluentd conf file that monitors a json based logfile and send new log entries to Stackdriver:
 ```
@@ -111,6 +129,3 @@ Here's an example google-fluentd conf file that monitors a json based logfile an
     tag exampletag
 </source>
 ```
-
-## Future
-A Stackdriver gRPC API based implementation is being considered. 


### PR DESCRIPTION
To better support k8s and and the latest swift logging api

- Add support for the new  'source' LogHandler log function's parameter
- Change the LogHandler from supporting only a file/filepath to a `Destination` enum permitting logging to stdout.