### PR TITLE
Add support for Logger `metadataProvider`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         // Swift logging API
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
         
         // Used for non-blocking fileIO
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.2.0")


### PR DESCRIPTION
As of version 1.5.0 of `swift-log` (https://github.com/apple/swift-log/releases/tag/1.5.0), a new `metadataProvider` was added. 

Not implementing this new value results in a number of warnings and missing functionality which this commit hopefully begins to address.