### PR TITLE
Use NIOLock instead of NIO.Lock

### DIFF
--- a/Sources/StackdriverLogging/StackdriverLogHandler.swift
+++ b/Sources/StackdriverLogging/StackdriverLogHandler.swift
@@ -241,7 +241,7 @@ extension StackdriverLogHandler {
         }
         
         public private(set) static var state = State.initial
-        private static let lock = Lock()
+        private static let lock = NIOLock()
         private static var eventLoopGroup: MultiThreadedEventLoopGroup?
         private static var threadPool: NIOThreadPool?
         


### PR DESCRIPTION
Now, `Lock` is marked as deprecated and it has warning.
Simply we can replace it as `NIOLock`.