### PR TITLE
Fix bug of metadataProvider and its priority

### DIFF
--- a/Sources/StackdriverLogging/StackdriverLogHandler.swift
+++ b/Sources/StackdriverLogging/StackdriverLogHandler.swift
@@ -63,26 +63,13 @@ public struct StackdriverLogHandler: LogHandler {
             // called recursively or in loops. Wrapping the calls in an autoreleasepool fixes the problems entirely on Darwin.
             // see: https://bugs.swift.org/browse/SR-5501
             withAutoReleasePool {
-                let entryMetadata: Logger.Metadata
-                
-                switch (metadata, self.metadata, self.metadataProvider) {
-                case (.some(let parameterMetadata), let metadata, .none):
-                    // parameterMetadata + metadata
-                    entryMetadata = metadata.merging(parameterMetadata) { $1 }
-                    
-                case (.none, let metadata, .some(let providerMetadata)):
-                    // metadata + providerMetadata
-                    entryMetadata = metadata.merging(providerMetadata.get()) { $1 }
-                    
-                case (.some(let parameterMetadata), let metadata, .some(let providerMetadata)):
-                    // parameterMetadata + metadata + providerMetadata
-                    entryMetadata = metadata
-                        .merging(providerMetadata.get()) { $1 }
-                        .merging(parameterMetadata) { $1 }
-                    
-                case (.none, let metadata, .none):
-                    // metadata only
-                    entryMetadata = metadata
+                var entryMetadata: Logger.Metadata = [:]
+                if let metadataProvider = self.metadataProvider {
+                    entryMetadata.merge(metadataProvider.get()) { $1 }
+                }
+                entryMetadata.merge(self.metadata) { $1 }
+                if let metadata = metadata {
+                    entryMetadata.merge(metadata) { $1 }
                 }
                 
                 var json = Self.unpackMetadata(.dictionary(entryMetadata)) as! [String: Any]

--- a/Sources/StackdriverLogging/StackdriverLogHandler.swift
+++ b/Sources/StackdriverLogging/StackdriverLogHandler.swift
@@ -57,6 +57,8 @@ public struct StackdriverLogHandler: LogHandler {
     }
     
     public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, source: String, file: String, function: String, line: UInt) {
+        let providerMetadata = self.metadataProvider?.get()
+
         let eventLoop = processingEventLoopGroup.next()
         eventLoop.execute {
             // JSONSerialization and its internal JSONWriter calls seem to leak significant memory, especially when
@@ -64,8 +66,8 @@ public struct StackdriverLogHandler: LogHandler {
             // see: https://bugs.swift.org/browse/SR-5501
             withAutoReleasePool {
                 var entryMetadata: Logger.Metadata = [:]
-                if let metadataProvider = self.metadataProvider {
-                    entryMetadata.merge(metadataProvider.get()) { $1 }
+                if let providerMetadata = providerMetadata {
+                    entryMetadata.merge(providerMetadata) { $1 }
                 }
                 entryMetadata.merge(self.metadata) { $1 }
                 if let metadata = metadata {


### PR DESCRIPTION
`providerMetadata.get()` is currently called in EventLoop, which is incorrect.
In order to correctly inherit TaskLocal values, we must call `.get()` from the caller's context.

And another, the metadata obtained from the `metadataProvider` is a global value.
I think the metadata given to the Logger should have more priority.

see also `console-kit`
https://github.com/vapor/console-kit/blob/a31f44ebfbd15a2cc0fda705279676773ac16355/Sources/ConsoleKitTerminal/Utilities/LoggerFragment.swift#L46-L51