### PR TITLE
Modernize and remove factory

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -12,12 +12,12 @@ let package = Package(
     dependencies: [
         // Swift logging API
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
-        
+
         // Used for threadPool
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.64.0"),
 
         // Used for fileIO
-        .package(url: "https://github.com/apple/swift-system", from: "1.2.1"),
+        .package(url: "https://github.com/apple/swift-system.git", from: "1.2.1"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,11 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "StackdriverLogging",
+    platforms: [.macOS(.v13), .iOS(.v16)],
     products: [
         .library(name: "StackdriverLogging", targets: ["StackdriverLogging"]),
     ],
@@ -12,11 +13,21 @@ let package = Package(
         // Swift logging API
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
         
-        // Used for non-blocking fileIO
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.2.0")
+        // Used for threadPool
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.64.0"),
+
+        // Used for fileIO
+        .package(url: "https://github.com/apple/swift-system", from: "1.2.1"),
     ],
     targets: [
-        .target(name: "StackdriverLogging", dependencies: ["NIO", "Logging"]),
+        .target(
+            name: "StackdriverLogging",
+            dependencies: [
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "SystemPackage", package: "swift-system"),
+            ]
+        ),
         .testTarget(name: "StackdriverLoggingTests", dependencies: ["StackdriverLogging"]),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -11,28 +11,11 @@ This Stackdriver `LogHandler` depends on [SwiftNIO](https://github.com/apple/swi
 ### Swift Package Manager
 
 ```swift
-.package(url: "https://github.com/Brainfinance/StackdriverLogging.git", from:"3.0.0")
+.package(url: "https://github.com/Brainfinance/StackdriverLogging.git", from: "4.0.0"),
 ```
 In your target's dependencies add `"StackdriverLogging"` e.g. like this:
 ```swift
 .target(name: "App", dependencies: ["StackdriverLogging"]),
-```
-
-## Bootstrapping 
-A factory is used to instantiate `StackdriverLogHandler` instances. Before bootstrapping your swift-log `LoggingSystem`, you must first call the  `StackdriverLogHandler.Factory.prepare(_:_:)` function with your logging destination.
-The Logging destination can be either the standard output or a file of your choice.
-You are also responsible for gracefully shutting down the NIO dependencies used internally by the `StackdriverLogHandler.Factory` by calling its shutdown function, preferably in a defer statement right after preparing the factory.
-```swift
-try StackdriverLogHandler.Factory.prepare(for: .stdout)
-defer {
-    try! StackdriverLogHandler.Factory.syncShutdownGracefully()
-}
-let logLevel = Logger.Level.info
-LoggingSystem.bootstrap { label -> LogHandler in
-    var logger = StackdriverLogHandler.Factory.make()
-    logger.logLevel = logLevel
-    return logger
-}
 ```
 
 ### Vapor 4
@@ -42,13 +25,9 @@ import App
 import Vapor
 
 var env = try Environment.detect()
-try StackdriverLogHandler.Factory.prepare(for: .stdout)
-defer {
-    try! StackdriverLogHandler.Factory.syncShutdownGracefully()
-}
 try LoggingSystem.bootstrap(from: &env) { (logLevel) -> (String) -> LogHandler in
     return { label -> LogHandler in
-        var logger = StackdriverLogHandler.Factory.make()
+        var logger = StackdriverLogHandler(destination: .stdout)
         logger.logLevel = logLevel
         return logger
     }

--- a/Sources/StackdriverLogging/StackdriverLogHandler.swift
+++ b/Sources/StackdriverLogging/StackdriverLogHandler.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Logging
 import NIO
-import NIOConcurrencyHelpers
 import SystemPackage
 
 /// `LogHandler` to log JSON to GCP Stackdriver using a fluentd config and the GCP logging-assistant.

--- a/Sources/StackdriverLogging/StackdriverLogHandler.swift
+++ b/Sources/StackdriverLogging/StackdriverLogHandler.swift
@@ -115,14 +115,22 @@ public struct StackdriverLogHandler: LogHandler {
     }
     
     /// ISO 8601 `DateFormatter` which is the accepted format for timestamps in Stackdriver
-    private static let iso8601DateFormatter: DateFormatter = {
+    private static var iso8601DateFormatter: DateFormatter {
+        let key = "StackdriverLogHandler_iso8601DateFormatter"
+        let threadLocal = Thread.current.threadDictionary
+        if let value = threadLocal[key] {
+            return value as! DateFormatter
+        }
+
         let formatter = DateFormatter()
         formatter.calendar = Calendar(identifier: .iso8601)
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+
+        threadLocal[key] = formatter
         return formatter
-    }()
+    }
     
     private static func unpackMetadata(_ value: Logger.MetadataValue) -> Any {
         /// Based on the core-foundation implementation of `JSONSerialization.isValidObject`, but optimized to reduce the amount of comparisons done per validation.

--- a/Sources/StackdriverLogging/StackdriverLogHandler.swift
+++ b/Sources/StackdriverLogging/StackdriverLogHandler.swift
@@ -63,26 +63,13 @@ public struct StackdriverLogHandler: LogHandler {
             // called recursively or in loops. Wrapping the calls in an autoreleasepool fixes the problems entirely on Darwin.
             // see: https://bugs.swift.org/browse/SR-5501
             withAutoReleasePool {
-                let entryMetadata: Logger.Metadata
-                
-                switch (metadata, self.metadata, self.metadataProvider) {
-                case (.some(let parameterMetadata), let metadata, .none):
-                    // parameterMetadata + metadata
-                    entryMetadata = metadata.merging(parameterMetadata) { $1 }
-                    
-                case (.none, let metadata, .some(let providerMetadata)):
-                    // metadata + providerMetadata
-                    entryMetadata = metadata.merging(providerMetadata.get()) { $1 }
-                    
-                case (.some(let parameterMetadata), let metadata, .some(let providerMetadata)):
-                    // parameterMetadata + metadata + providerMetadata
-                    entryMetadata = metadata
-                        .merging(providerMetadata.get()) { $1 }
-                        .merging(parameterMetadata) { $1 }
-                    
-                case (.none, let metadata, .none):
-                    // metadata only
-                    entryMetadata = metadata
+                var entryMetadata: Logger.Metadata = [:]
+                if let metadataProvider = self.metadataProvider {
+                    entryMetadata.merge(metadataProvider.get()) { $1 }
+                }
+                entryMetadata.merge(self.metadata) { $1 }
+                if let metadata = metadata {
+                    entryMetadata.merge(metadata) { $1 }
                 }
                 
                 var json = Self.unpackMetadata(.dictionary(entryMetadata)) as! [String: Any]

--- a/Sources/StackdriverLogging/StackdriverLogHandler.swift
+++ b/Sources/StackdriverLogging/StackdriverLogHandler.swift
@@ -2,6 +2,7 @@ import Foundation
 import Logging
 import NIO
 import NIOConcurrencyHelpers
+import SystemPackage
 
 /// `LogHandler` to log JSON to GCP Stackdriver using a fluentd config and the GCP logging-assistant.
 /// Use the `MetadataValue.stringConvertible` case to log non-string JSON values supported by JSONSerializer such as NSNull, Bool, Int, Float/Double, NSNumber, etc.
@@ -13,12 +14,36 @@ import NIOConcurrencyHelpers
 /// ** Use the `StackdriverLogHandler.Factory` to instantiate new `StackdriverLogHandler` instances.
 public struct StackdriverLogHandler: LogHandler {
     /// A `StackdriverLogHandler` output destination, can be either the standard output or a file.
-    public enum Destination: CustomStringConvertible {
-        case file(_ filepath: String)
-        case stdout
-        
+    public struct Destination: CustomStringConvertible {
+        internal enum Kind {
+            case file(_ filepath: String)
+            case stdout
+        }
+
+        internal var kind: Kind
+        internal var fd: SystemPackage.FileDescriptor
+
+        public static func file(_ filepath: String) throws -> Destination {
+            return .init(
+                kind: .file(filepath),
+                fd: try SystemPackage.FileDescriptor.open(
+                    FilePath(filepath),
+                    .writeOnly,
+                    options: [.append, .create],
+                    permissions: FilePermissions(rawValue: 0o644)
+                )
+            )
+        }
+
+        public static var stdout: Destination {
+            return .init(
+                kind: .stdout,
+                fd: .standardOutput
+            )
+        }
+
         public var description: String {
-            switch self {
+            switch kind {
             case .stdout:
                 return "standard output"
             case .file(let filePath):
@@ -32,19 +57,12 @@ public struct StackdriverLogHandler: LogHandler {
     
     public var logLevel: Logger.Level = .info
     
-    private let destination: Destination
-    
-    private let fileHandle: NIOFileHandle
-    
-    private let fileIO: NonBlockingFileIO
-    
-    private let processingEventLoopGroup: EventLoopGroup
-    
-    fileprivate init(destination: Destination, fileHandle: NIOFileHandle, fileIO: NonBlockingFileIO, processingEventLoopGroup: EventLoopGroup) {
+    private var destination: Destination
+    private var threadPool: NIOThreadPool
+
+    public init(destination: Destination, threadPool: NIOThreadPool = .singleton) throws {
         self.destination = destination
-        self.fileHandle = fileHandle
-        self.fileIO = fileIO
-        self.processingEventLoopGroup = processingEventLoopGroup
+        self.threadPool = threadPool
     }
     
     public subscript(metadataKey key: String) -> Logger.Metadata.Value? {
@@ -59,8 +77,8 @@ public struct StackdriverLogHandler: LogHandler {
     public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, source: String, file: String, function: String, line: UInt) {
         let providerMetadata = self.metadataProvider?.get()
 
-        let eventLoop = processingEventLoopGroup.next()
-        eventLoop.execute {
+        // run in threadpool or immediately (when threadpool is inactive)
+        threadPool.submit { _ in
             // JSONSerialization and its internal JSONWriter calls seem to leak significant memory, especially when
             // called recursively or in loops. Wrapping the calls in an autoreleasepool fixes the problems entirely on Darwin.
             // see: https://bugs.swift.org/browse/SR-5501
@@ -85,19 +103,20 @@ public struct StackdriverLogHandler: LogHandler {
                 json["sourceLocation"] = ["file": Self.conciseSourcePath(file), "line": line, "function": function]
                 json["timestamp"] = Self.iso8601DateFormatter.string(from: Date())
                 
+                let entry: Data
                 do {
-                    let entry = try JSONSerialization.data(withJSONObject: json, options: [])
-                    
-                    var buffer = ByteBufferAllocator().buffer(capacity: entry.count + 1)
-                    buffer.writeBytes(entry)
-                    buffer.writeInteger(0x0A, as: UInt8.self) // Appends a new line at the end of the entry
-                    
-                    self.fileIO.write(fileHandle: self.fileHandle, buffer: buffer, eventLoop: eventLoop)
-                        .whenFailure { error in
-                            print("Failed to write logfile entry to '\(self.destination)' with error: '\(error.localizedDescription)'")
-                        }
+                    var _entry = try JSONSerialization.data(withJSONObject: json, options: [])
+                    _entry.append(0x0A) // Appends a new line at the end of the entry
+                    entry = _entry
                 } catch {
                     print("Failed to serialize your log entry metadata to JSON with error: '\(error.localizedDescription)'")
+                    return
+                }
+
+                do {
+                    try self.destination.fd.writeAll(entry)
+                } catch {
+                    print("Failed to write logfile entry to '\(self.destination)' with error: '\(error.localizedDescription)'")
                 }
             }
         }
@@ -220,96 +239,6 @@ extension StackdriverLogHandler {
                 return .critical
             }
         }
-    }
-    
-}
-
-extension StackdriverLogHandler {
-    /// A factory enum used to create new instances of `StackdriverLogHandler`.
-    /// You must first prepare it by calling the `prepare(_:_:)` function. You must also shutdown the internal dependencies
-    /// created by this factory and used internally by the `StackdriverLogHandler`s by calling the `syncShutdownGracefully`.
-    /// This is commonly done in a defer statement after preparing the facotry using the `prepare(_:_:)
-    public enum Factory {
-        
-        public enum State {
-            case initial
-            case running
-            case shutdown
-        }
-        
-        public private(set) static var state = State.initial
-        private static let lock = NIOLock()
-        private static var eventLoopGroup: MultiThreadedEventLoopGroup?
-        private static var threadPool: NIOThreadPool?
-        
-        private static var logger: StackdriverLogHandler!
-        
-        /// Shuts the `StackdriverLogHandler.Factory` down which will close and shutdown the `NIOThreadPool` and the
-        /// `MultiThreadedEventLoopGroup` used internally by the `StackdriverLogHandler`s to write log entries.
-        ///
-        /// A good practice is to call this in a defer statement after preparing the factory using the `prepare(_:_:)` function.
-        public static func syncShutdownGracefully() throws {
-            defer {
-                self.lock.withLockVoid {
-                    self.state = .shutdown
-                }
-            }
-            try self.threadPool?.syncShutdownGracefully()
-            try self.eventLoopGroup?.syncShutdownGracefully()
-        }
-        
-        /// Prepares the factory's internal so that new `LogHandler`s can be made using its `make` function. This will create
-        /// certain internal dependencies that must be shutdown before your application exits using the `syncShutdownGracefully` function.
-        ///
-        /// - Parameters:
-        ///   - destination: The destination at which to send the logs to such as the standard output or a file.
-        ///   - numberOfThreads: The number of threads that will be used to process and write new log entries.
-        public static func prepare(
-            for destination: StackdriverLogHandler.Destination,
-            numberOfThreads: Int = NonBlockingFileIO.defaultThreadPoolSize
-        ) throws {
-            self.logger = try lock.withLock {
-                assert(state == .initial, "`StackdriverLogHandler.Factory.prepare` should only be called once.")
-                defer {
-                    self.state = .running
-                }
-
-                let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: numberOfThreads)
-                self.eventLoopGroup = eventLoopGroup
-                
-                let threadPool = NIOThreadPool(numberOfThreads: numberOfThreads)
-                threadPool.start()
-                self.threadPool = threadPool
-                
-                let fileIO = NonBlockingFileIO(threadPool: threadPool)
-                
-                let fileHandle: NIOFileHandle
-                switch destination {
-                case .stdout:
-                    fileHandle = NIOFileHandle(descriptor: FileHandle.standardOutput.fileDescriptor)
-                case .file(let filepath):
-                    fileHandle = try NIOFileHandle(
-                        path: filepath,
-                        mode: .write,
-                        flags: .posix(flags: O_APPEND | O_CREAT, mode: S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH)
-                    )
-                }
-                
-                return StackdriverLogHandler(
-                    destination: destination,
-                    fileHandle: fileHandle,
-                    fileIO: fileIO,
-                    processingEventLoopGroup: eventLoopGroup
-                )
-            }
-        }
-        
-        /// Creates a new `StackdriverLogHandler` instance.
-        public static func make() -> StackdriverLogHandler {
-            assert(state == .running, "You must prepare the `StackdriverLogHandler.Factory` with the `prepare` method before creating new loggers.")
-            return logger
-        }
-        
     }
 }
 

--- a/Sources/StackdriverLogging/StackdriverLogHandler.swift
+++ b/Sources/StackdriverLogging/StackdriverLogHandler.swift
@@ -57,6 +57,8 @@ public struct StackdriverLogHandler: LogHandler {
     }
     
     public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, source: String, file: String, function: String, line: UInt) {
+        let providerMetadata = self.metadataProvider?.get()
+
         let eventLoop = processingEventLoopGroup.next()
         eventLoop.execute {
             // JSONSerialization and its internal JSONWriter calls seem to leak significant memory, especially when
@@ -64,8 +66,8 @@ public struct StackdriverLogHandler: LogHandler {
             // see: https://bugs.swift.org/browse/SR-5501
             withAutoReleasePool {
                 var entryMetadata: Logger.Metadata = [:]
-                if let metadataProvider = self.metadataProvider {
-                    entryMetadata.merge(metadataProvider.get()) { $1 }
+                if let providerMetadata = providerMetadata {
+                    entryMetadata.merge(providerMetadata) { $1 }
                 }
                 entryMetadata.merge(self.metadata) { $1 }
                 if let metadata = metadata {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-import StackdriverLoggingTests
-
-var tests = [XCTestCaseEntry]()
-tests += StackdriverLoggingTests.allTests()
-XCTMain(tests)

--- a/Tests/StackdriverLoggingTests/StackdriverLoggerTests.swift
+++ b/Tests/StackdriverLoggingTests/StackdriverLoggerTests.swift
@@ -1,6 +1,6 @@
 import NIO
+import StackdriverLogging
 import XCTest
-@testable import StackdriverLogging
 
 final class StackdriverLoggingTests: XCTestCase {
     func testStdout() {

--- a/Tests/StackdriverLoggingTests/StackdriverLoggerTests.swift
+++ b/Tests/StackdriverLoggingTests/StackdriverLoggerTests.swift
@@ -1,15 +1,65 @@
+import NIO
 import XCTest
 @testable import StackdriverLogging
 
 final class StackdriverLoggingTests: XCTestCase {
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-//        XCTAssertEqual(StackdriverLogging().text, "Hello, World!")
+    func testStdout() {
+        let handler = StackdriverLogHandler(destination: .stdout)
+        handler.log(
+            level: .error,
+            message: "test error log 1",
+            metadata: [
+                "test-metadata": "hello",
+            ],
+            source: "StackdriverLoggingTests",
+            file: #file,
+            function: #function,
+            line: #line
+        )
+        handler.log(
+            level: .error,
+            message: "test error log 2",
+            metadata: nil,
+            source: "StackdriverLoggingTests",
+            file: #file,
+            function: #function,
+            line: #line
+        )
     }
 
-    static var allTests = [
-        ("testExample", testExample),
-    ]
+    func testFile() throws {
+        let tmpPath = NSTemporaryDirectory() + "/\(Self.self)+\(UUID()).log"
+
+        let inactiveTP = NIOThreadPool(numberOfThreads: 1)
+        let handler = try StackdriverLogHandler(destination: .file(tmpPath), threadPool: inactiveTP)
+        handler.log(
+            level: .error,
+            message: "test error log 1",
+            metadata: nil,
+            source: "StackdriverLoggingTests",
+            file: #file,
+            function: #function,
+            line: #line
+        )
+
+        for (i, line) in try String(contentsOfFile: tmpPath).split(separator: "\n").enumerated() {
+            XCTAssertTrue(line.contains("test error log \(i + 1)"))
+        }
+
+        handler.log(
+            level: .error,
+            message: "test error log 2",
+            metadata: nil,
+            source: "StackdriverLoggingTests",
+            file: #file,
+            function: #function,
+            line: #line
+        )
+
+        for (i, line) in try String(contentsOfFile: tmpPath).split(separator: "\n").enumerated() {
+            XCTAssertTrue(line.contains("test error log \(i + 1)"))
+        }
+
+        try FileManager.default.removeItem(atPath: tmpPath)
+    }
 }

--- a/Tests/StackdriverLoggingTests/XCTestManifests.swift
+++ b/Tests/StackdriverLoggingTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(StackdriverLoggingTests.allTests),
-    ]
-}
-#endif


### PR DESCRIPTION
Modernize the implementation overall.

## Changes
- Make the setup of `EventLoopGroup` unnecessary and switch the worker queue to `NIOThreadPool`.
- Use [swift-system](https://github.com/apple/swift-system) for file I/O.
  (It might appear that the file I/O has become blocking, but it is the same as `NonBlockingFileIO`.)
  - Because `NonBlockingFileIO` is a bit outdated.
  - `NIOFileSystem` in swift-nio also seems good, but it is not stable yet.
- Remove `StackdriverLogHandler.Factory`, as there is no need for setup due to the default singleton `NIOThreadPool`.
  - Those who want customization can use their own `NIOThreadPool`.
- Delete old test support files for Linux and additionally implement tests.

This PR including https://github.com/brainfinance/StackdriverLogging/pull/7 and https://github.com/brainfinance/StackdriverLogging/pull/6 .