### PR TITLE
Fix bug in StackdriverLogHandler.swift

### DIFF
--- a/Sources/StackdriverLogging/StackdriverLogHandler.swift
+++ b/Sources/StackdriverLogging/StackdriverLogHandler.swift
@@ -281,7 +281,7 @@ extension Logger {
         metadataValue["requestUrl"] = .optionalString(requestUrl)
         metadataValue["requestSize"] = .optionalString(requestSize)
         metadataValue["status"] = .optionalStringConvertible(status)
-        metadataValue["responseSize"] = .optionalString(requestSize)
+        metadataValue["responseSize"] = .optionalString(responseSize)
         metadataValue["userAgent"] = .optionalString(userAgent)
         metadataValue["remoteIp"] = .optionalString(remoteIp)
         metadataValue["serverIp"] = .optionalString(serverIp)


### PR DESCRIPTION
Response size was incorrectly using the request size introducing invalid logs