### PR TITLE
Configuration Source Location logging

### DIFF
--- a/Tests/StackdriverLoggingTests/StackdriverLoggerTests.swift
+++ b/Tests/StackdriverLoggingTests/StackdriverLoggerTests.swift
@@ -62,4 +62,20 @@ final class StackdriverLoggingTests: XCTestCase {
 
         try FileManager.default.removeItem(atPath: tmpPath)
     }
+
+    func testSourceLocationLogLevel() throws {
+        let tmpPath = NSTemporaryDirectory() + "/\(Self.self)+\(UUID()).log"
+        let handler = try StackdriverLogHandler(destination: .file(tmpPath), sourceLocationLogLevel: .error)
+        handler.log(level: .warning, message: "Some message", metadata: nil, source: "StackdriverLoggingTests", file: #file, function: #function, line: #line)
+
+        for line in try String(contentsOfFile: tmpPath).split(separator: "\n") {
+            XCTAssertFalse(line.contains("sourceLocation"))
+        }
+
+        handler.log(level: .error, message: "Some message", metadata: nil, source: "StackdriverLoggingTests", file: #file, function: #function, line: #line)
+
+        for line in try String(contentsOfFile: tmpPath).split(separator: "\n") {
+            XCTAssertTrue(line.contains("sourceLocation"))
+        }
+    }
 }


### PR DESCRIPTION
Logging the source location for each log entry can be unnecessary in some scenarios and not desirable due to storage costs for debug logs etc.

This PR introduces a configuration option to set the log level at which source location is logged so it can be discarded for certain log levels