### PR TITLE
Add Google Cloud Error Annotation

### DIFF
--- a/Sources/StackdriverLogging/StackdriverLogHandler.swift
+++ b/Sources/StackdriverLogging/StackdriverLogHandler.swift
@@ -11,7 +11,7 @@ import SystemPackage
 /// The log entry format matches https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
 ///
 /// ** Use the `StackdriverLogHandler.Factory` to instantiate new `StackdriverLogHandler` instances.
-public struct StackdriverLogHandler: LogHandler {
+public struct `StackdriverLogHandler`: LogHandler {
     /// A `StackdriverLogHandler` output destination, can be either the standard output or a file.
     public struct Destination: CustomStringConvertible {
         internal enum Kind {

--- a/Sources/StackdriverLogging/StackdriverLogHandler.swift
+++ b/Sources/StackdriverLogging/StackdriverLogHandler.swift
@@ -59,16 +59,19 @@ public struct StackdriverLogHandler: LogHandler {
     private var destination: Destination
     private var threadPool: NIOThreadPool
     private var sourceLocationLogLevel: Logger.Level
+    private let enableErrorTagging: Bool
     
     /// Create a new StackdriverLogHandler
     /// - Parameters:
     ///   - destination: The ``Destination`` to write the log entries to, such as a file or stdout
     ///   - threadPool: The thread pool to use for writing log entries. Defaults to the singleton `NIOThreadPool`.
     ///   - sourceLocationLogLevel: The level to log the source location at. Defaults to `.trace` - i.e. all levels will log the source location.
-    public init(destination: Destination, threadPool: NIOThreadPool = .singleton, sourceLocationLogLevel: Logger.Level = .trace) {
+    ///   - enableErrorTagging: Enable error tagging in the log messages for error and critiical log levels. See https://cloud.google.com/error-reporting/docs/formatting-error-messages#log-text
+    public init(destination: Destination, threadPool: NIOThreadPool = .singleton, sourceLocationLogLevel: Logger.Level = .trace, enableErrorTagging: Bool = false) {
         self.destination = destination
         self.threadPool = threadPool
         self.sourceLocationLogLevel = sourceLocationLogLevel
+        self.enableErrorTagging = enableErrorTagging
     }
     
     public subscript(metadataKey key: String) -> Logger.Metadata.Value? {
@@ -108,8 +111,7 @@ public struct StackdriverLogHandler: LogHandler {
                 json["message"] = message.description
                 json["severity"] = Severity.fromLoggerLevel(level).rawValue
                 
-                if level >= .error {
-                    // https://cloud.google.com/error-reporting/docs/formatting-error-messages#log-text
+                if level >= .error && self.enableErrorTagging {
                     json["@type"] = "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent"
                 }
                 

--- a/Sources/StackdriverLogging/StackdriverLogHandler.swift
+++ b/Sources/StackdriverLogging/StackdriverLogHandler.swift
@@ -11,7 +11,7 @@ import SystemPackage
 /// The log entry format matches https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
 ///
 /// ** Use the `StackdriverLogHandler.Factory` to instantiate new `StackdriverLogHandler` instances.
-public struct `StackdriverLogHandler`: LogHandler {
+public struct StackdriverLogHandler: LogHandler {
     /// A `StackdriverLogHandler` output destination, can be either the standard output or a file.
     public struct Destination: CustomStringConvertible {
         internal enum Kind {

--- a/Sources/StackdriverLogging/StackdriverLogHandler.swift
+++ b/Sources/StackdriverLogging/StackdriverLogHandler.swift
@@ -107,6 +107,12 @@ public struct StackdriverLogHandler: LogHandler {
                 
                 json["message"] = message.description
                 json["severity"] = Severity.fromLoggerLevel(level).rawValue
+                
+                if level >= .error {
+                    // https://cloud.google.com/error-reporting/docs/formatting-error-messages#log-text
+                    json["@type"] = "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent"
+                }
+                
                 if level >= sourceLocationLogLevel {
                     json["sourceLocation"] = [
                         "file": Self.conciseSourcePath(file),

--- a/Tests/StackdriverLoggingTests/StackdriverLoggerTests.swift
+++ b/Tests/StackdriverLoggingTests/StackdriverLoggerTests.swift
@@ -121,7 +121,7 @@ final class StackdriverLoggingTests: XCTestCase {
 
         var foundLines = false
         for line in try String(contentsOfFile: tmpPath).split(separator: "\n") {
-            XCTAssertTrue(line.contains("\"@type\": \"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent\","))
+            XCTAssertTrue(line.contains("@type"))
             foundLines = true
         }
         XCTAssertTrue(foundLines)

--- a/Tests/StackdriverLoggingTests/StackdriverLoggerTests.swift
+++ b/Tests/StackdriverLoggingTests/StackdriverLoggerTests.swift
@@ -78,4 +78,55 @@ final class StackdriverLoggingTests: XCTestCase {
             XCTAssertTrue(line.contains("sourceLocation"))
         }
     }
+    
+    func testErrorLogReportsType() throws {
+        let tmpPath = NSTemporaryDirectory() + "/\(Self.self)+\(UUID()).log"
+
+        let handler = try StackdriverLogHandler(destination: .file(tmpPath))
+        handler.log(
+            level: .error,
+            message: "test error log 1",
+            metadata: nil,
+            source: "StackdriverLoggingTests",
+            file: #file,
+            function: #function,
+            line: #line
+        )
+
+        for (_, line) in try String(contentsOfFile: tmpPath).split(separator: "\n").enumerated() {
+            XCTAssertTrue(line.contains("\"@type\": \"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent\","))
+        }
+        
+        handler.log(
+            level: .critical,
+            message: "test error log 1",
+            metadata: nil,
+            source: "StackdriverLoggingTests",
+            file: #file,
+            function: #function,
+            line: #line
+        )
+
+        for (_, line) in try String(contentsOfFile: tmpPath).split(separator: "\n").enumerated() {
+            XCTAssertTrue(line.contains("\"@type\": \"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent\","))
+        }
+        
+        handler.log(
+            level: .info,
+            message: "No error",
+            metadata: nil,
+            source: "StackdriverLoggingTests",
+            file: #file,
+            function: #function,
+            line: #line
+        )
+
+        for (_, line) in try String(contentsOfFile: tmpPath).split(separator: "\n").enumerated() {
+            XCTAssertFalse(line.contains("\"@type\": \"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent\","))
+        }
+        
+        
+
+        try FileManager.default.removeItem(atPath: tmpPath)
+    }
 }

--- a/Tests/StackdriverLoggingTests/StackdriverLoggerTests.swift
+++ b/Tests/StackdriverLoggingTests/StackdriverLoggerTests.swift
@@ -28,7 +28,7 @@ final class StackdriverLoggingTests: XCTestCase {
     }
 
     func testFile() throws {
-        let tmpPath = NSTemporaryDirectory() + "/\(Self.self)+\(UUID()).log"
+        let tmpPath = NSTemporaryDirectory() + "\(Self.self)+\(UUID()).log"
 
         let inactiveTP = NIOThreadPool(numberOfThreads: 1)
         let handler = try StackdriverLogHandler(destination: .file(tmpPath), threadPool: inactiveTP)
@@ -42,9 +42,12 @@ final class StackdriverLoggingTests: XCTestCase {
             line: #line
         )
 
+        var foundLines = false
         for (i, line) in try String(contentsOfFile: tmpPath).split(separator: "\n").enumerated() {
             XCTAssertTrue(line.contains("test error log \(i + 1)"))
+            foundLines = true
         }
+        XCTAssertTrue(foundLines)
 
         handler.log(
             level: .error,
@@ -61,28 +64,41 @@ final class StackdriverLoggingTests: XCTestCase {
         }
 
         try FileManager.default.removeItem(atPath: tmpPath)
+        try inactiveTP.syncShutdownGracefully()
     }
 
     func testSourceLocationLogLevel() throws {
-        let tmpPath = NSTemporaryDirectory() + "/\(Self.self)+\(UUID()).log"
-        let handler = try StackdriverLogHandler(destination: .file(tmpPath), sourceLocationLogLevel: .error)
+        let inactiveTP = NIOThreadPool(numberOfThreads: 1)
+        let tmpPath = NSTemporaryDirectory() + "\(Self.self)+\(UUID()).log"
+        let handler = try StackdriverLogHandler(destination: .file(tmpPath), threadPool: inactiveTP, sourceLocationLogLevel: .error)
         handler.log(level: .warning, message: "Some message", metadata: nil, source: "StackdriverLoggingTests", file: #file, function: #function, line: #line)
 
+        var foundLines = false
         for line in try String(contentsOfFile: tmpPath).split(separator: "\n") {
             XCTAssertFalse(line.contains("sourceLocation"))
+            foundLines = true
         }
+        XCTAssertTrue(foundLines)
 
         handler.log(level: .error, message: "Some message", metadata: nil, source: "StackdriverLoggingTests", file: #file, function: #function, line: #line)
 
-        for line in try String(contentsOfFile: tmpPath).split(separator: "\n") {
-            XCTAssertTrue(line.contains("sourceLocation"))
+        foundLines = false
+        for (index, line) in try String(contentsOfFile: tmpPath).split(separator: "\n").enumerated() {
+            // Ignore the first line as that's the warning location
+            if index > 0 {
+                XCTAssertTrue(line.contains("sourceLocation"))
+                foundLines = true
+            }
         }
+        XCTAssertTrue(foundLines)
+        try inactiveTP.syncShutdownGracefully()
     }
     
-    func testErrorLogReportsType() throws {
-        let tmpPath = NSTemporaryDirectory() + "/\(Self.self)+\(UUID()).log"
-
-        let handler = try StackdriverLogHandler(destination: .file(tmpPath))
+    func testErrorLogReportsTypeAtErrorLevel() throws {
+        let tmpPath = NSTemporaryDirectory() + "\(Self.self)+\(UUID()).log"
+        let tp = NIOThreadPool(numberOfThreads: 1)
+        
+        let handler = try StackdriverLogHandler(destination: .file(tmpPath), threadPool: tp)
         handler.log(
             level: .error,
             message: "test error log 1",
@@ -92,10 +108,6 @@ final class StackdriverLoggingTests: XCTestCase {
             function: #function,
             line: #line
         )
-
-        for (_, line) in try String(contentsOfFile: tmpPath).split(separator: "\n").enumerated() {
-            XCTAssertTrue(line.contains("\"@type\": \"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent\","))
-        }
         
         handler.log(
             level: .critical,
@@ -107,9 +119,12 @@ final class StackdriverLoggingTests: XCTestCase {
             line: #line
         )
 
-        for (_, line) in try String(contentsOfFile: tmpPath).split(separator: "\n").enumerated() {
+        var foundLines = false
+        for line in try String(contentsOfFile: tmpPath).split(separator: "\n") {
             XCTAssertTrue(line.contains("\"@type\": \"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent\","))
+            foundLines = true
         }
+        XCTAssertTrue(foundLines)
         
         handler.log(
             level: .info,
@@ -121,12 +136,10 @@ final class StackdriverLoggingTests: XCTestCase {
             line: #line
         )
 
-        for (_, line) in try String(contentsOfFile: tmpPath).split(separator: "\n").enumerated() {
-            XCTAssertFalse(line.contains("\"@type\": \"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent\","))
-        }
+        let lastLine = try XCTUnwrap(String(contentsOfFile: tmpPath).split(separator: "\n").last)
+            XCTAssertFalse(lastLine.contains("\"@type\": \"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent\","))
         
-        
-
         try FileManager.default.removeItem(atPath: tmpPath)
+        try tp.syncShutdownGracefully()
     }
 }


### PR DESCRIPTION
Add the `@error` annotation to error logs as per https://cloud.google.com/error-reporting/docs/formatting-error-messages#log-text so they can be picked up by tooling

Additionally fix the tests. There appears to be a race condition when using the singleton in that logs could be delayed so fixed it by using a dedicated thread pool for the handler in the test. Also add assertions to make sure the tests actually run
